### PR TITLE
add goatcounter analytics

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,4 +42,7 @@
 	<meta name="msapplication-TileColor" content="#ffffff">
 	<meta name="msapplication-config" content="/assets/favicons/browserconfig.xml">
 	<meta name="theme-color" content="#ffffff">
+
+	<!-- GoatCounter analytics - https://sheffieldhackspace.goatcounter.com/ -->
+	<script data-goatcounter="https://sheffieldhackspace.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </head>


### PR DESCRIPTION
[GoatCounter](https://www.goatcounter.com/) is:

> an [open source](https://github.com/arp242/goatcounter) web analytics platform available as a free donation-supported hosted service or self-hosted app. It aims to offer easy to use and meaningful privacy-friendly web analytics as an alternative to Google Analytics or Matomo.

I add a single script to the `<head>` of each page which enables this privacy-friendly analytic

For an example of GoatCounter in use for a small site, see <https://liputenpo.goatcounter.com/>