### PR TITLE
add "next: 10 days" marker to craft night (with JavaScript)

### DIFF
--- a/_includes/calendar.md
+++ b/_includes/calendar.md
@@ -6,7 +6,7 @@
 
 ### Themed nights
 
-<details class="themed-night" markdown=1><summary><span markdown=1>*Craft Night*</span>: Every 1st and 3rd Wednesday of the month, 6 - 9 pm</summary>
+<details class="themed-night" markdown=1><summary><span markdown=1>*Craft Night*</span>: Every 1st and 3rd Wednesday of the month, 6 - 9 pm<span id="cal-next" style="opacity:0.5;"></span></summary>
 
 Alex H and Alfie will be opening up to do crafts, from sewing, clothes alterations, and upholstery, through origami, pom-pom making, felting, and more. Basically anything that doesn't involve a laptop!
 
@@ -17,3 +17,5 @@ There are lots of needles, thread, and offcut material, so without bringing anyt
 Every 1st and 3rd Wednesday of the month from 6pm-9pm.
 
 </details>
+
+<script src="/assets/get-next-wednesday.js"></script>

--- a/assets/get-next-wednesday.js
+++ b/assets/get-next-wednesday.js
@@ -1,0 +1,45 @@
+document.addEventListener("DOMContentLoaded", () => {
+  let cal = document.getElementById("cal-next");
+  if (!cal) return;
+
+  let today = new Date();
+  let today_day = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate()
+  );
+  let next_date;
+  // check next few weeks
+  for (let i = 0; i < 22; i++) {
+    next = new Date(
+      today_day.getFullYear(),
+      today_day.getMonth(),
+      today_day.getDate() + i
+    );
+    // skip: not a Wednesday
+    if (next.getDay() != 3) {
+      continue;
+    }
+    // skip: is not between 1 and 7 days or 15 and 21 days through the month
+    let date = next.getDate();
+    if (
+      !(
+        (
+          (date >= 1 && date <= 7) || // week 1
+          (date >= 15 && date <= 21)
+        ) // week 3
+      )
+    ) {
+      continue;
+    }
+    next_date = new Date(
+      Date.UTC(next.getFullYear(), next.getMonth(), next.getDate(), 18)
+    );
+    break;
+  }
+  const oneDay = 24 * 60 * 60 * 1000;
+  const days_til = Math.round(Math.abs((today - next_date) / oneDay));
+  cal.innerHTML = ` (next in ${days_til} days, ${next_date.getFullYear()}-${
+    next_date.getMonth() + 1
+  }-${next_date.getDate()})`;
+});


### PR DESCRIPTION
this is just a bit of fun

a piece of JavaScript (scary stuff) to show when the next "1st or 3rd Wednesday of the month" is

it looks like this

![image](https://github.com/user-attachments/assets/33659dc1-43d7-4232-a12e-ac98341512b4)

preview on <https://shhm-next-wednesday.surge.sh/>

if JavaScript is disabled, nothing will be displayed