### PR TITLE
Add/google site verification

### DIFF
--- a/_pages/googleba9233d8dfde703b.html
+++ b/_pages/googleba9233d8dfde703b.html
@@ -1,0 +1,4 @@
+---
+permalink: "/googleba9233d8dfde703b.html"
+---
+google-site-verification: googleba9233d8dfde703b.html


### PR DESCRIPTION
it would be good to be able to see the Google Search Console for the site

for example the [goatcounter](https://sheffieldhackspacewebsite.goatcounter.com/) shows a spike around the 25th April. Why? Who knows, but maybe Google Search Console can answer some questions.

![image](https://github.com/user-attachments/assets/7a8b0980-1836-4da2-a80a-107ea57417e9)
