### PR TITLE
serve icon from web root

### DIFF
--- a/_includes/contact-list.html
+++ b/_includes/contact-list.html
@@ -16,7 +16,7 @@
 	<li>
 		{% comment %} basically basic theme doesn't have a dokuwiki logo :( {% endcomment %}
 		<a href="{{ site.wiki }}">
-  			<span class="icon"><img src="assets/images/dokuwiki-logo.svg"/></span>
+  			<span class="icon"><img src="/assets/images/dokuwiki-logo.svg"/></span>
   			<span class="label">Wiki</span>
 		</a>
 	</li>


### PR DESCRIPTION
otherwise it's not loaded on sub-pages

e.g., https://www.sheffieldhackspace.org.uk/calendar/

![image](https://github.com/user-attachments/assets/331ffa48-85e3-4e7a-a7a9-ae62b49c9b11)

we were so focused on trailing slashes @Rijndael1998 