### PR TITLE
add search box to `/blog/` page

### DIFF
--- a/.github/workflows/jekyll-deploy.yml
+++ b/.github/workflows/jekyll-deploy.yml
@@ -33,20 +33,32 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1 # v1.161.0
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
+      
+      - name: Setup Node for PageFind
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+
+      - name: Build search index with pagefind
+        run: npx -y pagefind --site _site
+
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/jekyll-test.yml
+++ b/.github/workflows/jekyll-test.yml
@@ -16,14 +16,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1 # v1.161.0
         with:
           ruby-version: "3.1" # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+
+      - name: Setup Node for PageFind  
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+
+      - name: Build search index with pagefind
+        run: npx -y pagefind --site _site

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -4,3 +4,11 @@ title: Blog
 permalink: /blog/
 paginate: true
 ---
+<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+<script src="/pagefind/pagefind-ui.js"></script>
+<div id="search" style="margin: 1rem 0 1.5rem;"></div>
+<script>
+    window.addEventListener('DOMContentLoaded', (event) => {
+        new PagefindUI({ element: "#search", showSubResults: true });
+    });
+</script>


### PR DESCRIPTION
generate search data on site-build with PageFind - https://pagefind.app/

example on <http://sheffieldhackspace.alifeee.co.uk/blog/>

the search bar is just on the blogs page - but it also searches the normal pages. visually, it fits in pretty innocuously

![image](https://github.com/user-attachments/assets/53ede631-4f14-41ef-a089-c25b291321ce)

![image](https://github.com/user-attachments/assets/b32098b0-722a-4e18-a2f5-25ede922ec47)

output of Pagefind:

![image](https://github.com/user-attachments/assets/aabc37b8-bb00-489f-84c8-26de731f9346)
