### PR TITLE
remove twitter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,6 @@ goat_counter_url: "https://sheffieldhackspacewebsite.goatcounter.com"
 # socials
 email: trustees@sheffieldhackspace.org.uk
 wiki: https://wiki.sheffieldhackspace.org.uk/
-twitter_username: "@shhmakers"
 github_username:  "sheffieldhackspace"
 facebook_username: "SHHMakers"
 instagram_username: "SHHMakers"


### PR DESCRIPTION
the Twitter profile was long killed by Twitter

<img width="511" height="457" alt="image" src="https://github.com/user-attachments/assets/d638746b-656f-4b70-bb2d-9010ab8e6e52" />

and it was agreed not to revive it

https://wiki.sheffieldhackspace.org.uk/members/info/notes#:~:text=agreement%20to%20leave%20Twitter%20dead

if anyone feels we are lacking a microblogging platform, I suggest Mastodon or Bluesky instead.

<img width="345" height="314" alt="image" src="https://github.com/user-attachments/assets/3134d12a-92f1-4359-86f7-0fe4257518ea" />
